### PR TITLE
Fixing sample bug.

### DIFF
--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianFactor.java
@@ -679,11 +679,11 @@ public class BayesianFactor implements Factor<BayesianFactor> {
 		return this.marginalize(this.getDomain().getVariables()[0]).getValue() == 1;
 	}
 
-	public static BayesianFactor random(Strides left, Strides right, int num_decimals, boolean zero_allowed) {
+	public static BayesianFactor random(Strides left, Strides right) {
 		double[][] data = new double[right.getCombinations()][];
 
 		for (int i = 0; i < data.length; i++) {
-			data[i] = RandomUtil.sampleNormalized(left.getCombinations(), num_decimals, zero_allowed);
+			data[i] = RandomUtil.sampleNormalized(left.getCombinations());
 		}
 
 		return new BayesianFactor(left.concat(right), Doubles.concat(data), false);
@@ -790,20 +790,17 @@ public class BayesianFactor implements Factor<BayesianFactor> {
 	 * Creates a new model with the same structure but with random probability values
 	 *
 	 * @param model
-	 * @param num_decimals
-	 * @param zero_allowed
 	 * @param variables
 	 * @return
 	 */
-	public static GraphicalModel<BayesianFactor> randomModel(GraphicalModel<BayesianFactor> model, int num_decimals,
-	                                                         boolean zero_allowed, int... variables) {
+	public static GraphicalModel<BayesianFactor> randomModel(GraphicalModel<BayesianFactor> model, int... variables) {
 		GraphicalModel<BayesianFactor> rmodel = model.copy();
 
 		if (variables.length == 0)
 			variables = rmodel.getVariables();
 
 		for (int v : variables) {
-			BayesianFactor f = random(rmodel.getDomain(v), rmodel.getDomain(rmodel.getParents(v)), num_decimals, zero_allowed);
+			BayesianFactor f = random(rmodel.getDomain(v), rmodel.getDomain(rmodel.getParents(v)));
 			rmodel.setFactor(v, f);
 		}
 
@@ -819,15 +816,15 @@ public class BayesianFactor implements Factor<BayesianFactor> {
 	@Override
 	public ObservationBuilder sample() {
 		double[] probs = this.getData();
-		if (this.getDomain().getVariables().length > 1) {
+		if (getDomain().getVariables().length > 1) {
 			double sum = DoubleStream.of(probs).sum();
 			probs = DoubleStream.of(probs).map(p -> p / sum).toArray();
 		}
-		return this.getDomain().observationOf(RandomUtil.sampleCategorical(probs));
+		return getDomain().observationOf(RandomUtil.sampleCategorical(probs));
 	}
 
 	public BayesianFactor scalarMultiply(double k) {
-		BayesianFactor f = this.copy();
+		BayesianFactor f = copy();
 		for (int i = 0; i < f.getData().length; i++) {
 			f.setValueAt(f.getValueAt(i) * k, i);
 		}

--- a/src/main/java/ch/idsia/crema/factor/credal/vertex/VertexFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/credal/vertex/VertexFactor.java
@@ -760,7 +760,7 @@ public class VertexFactor implements CredalFactor, SeparatelySpecified<VertexFac
 
         // generate k precise factor
         List PMFs = IntStream.range(0, k - 1)
-                .mapToObj(i -> BayesianFactor.random(leftDomain, Strides.empty(), num_decimals, zero_allowed))
+                .mapToObj(i -> BayesianFactor.random(leftDomain, Strides.empty()))
                 .map(f -> new BayesianToVertex().apply(f, leftVar))
                 .collect(Collectors.toList());
 
@@ -770,7 +770,7 @@ public class VertexFactor implements CredalFactor, SeparatelySpecified<VertexFac
             if (k > 1) {
                 // generate a new distribution
                 VertexFactor f = new BayesianToVertex().apply(
-                        BayesianFactor.random(leftDomain, Strides.empty(), num_decimals, zero_allowed),
+                        BayesianFactor.random(leftDomain, Strides.empty()),
                         leftVar);
                 PMFs.add(f);
             }

--- a/src/main/java/ch/idsia/crema/utility/ArraysUtil.java
+++ b/src/main/java/ch/idsia/crema/utility/ArraysUtil.java
@@ -1081,4 +1081,28 @@ public class ArraysUtil {
 		return Arrays.equals(arr1, arr2);
 	}
 
+	public static void shuffle(double[] array) {
+		int index;
+		double temp;
+		Random random = new Random();
+		for (int i = array.length - 1; i > 0; i--) {
+			index = random.nextInt(i + 1);
+			temp = array[index];
+			array[index] = array[i];
+			array[i] = temp;
+		}
+	}
+
+	public static void shuffle(int[] array) {
+		int index;
+		int temp;
+		Random random = new Random();
+		for (int i = array.length - 1; i > 0; i--) {
+			index = random.nextInt(i + 1);
+			temp = array[index];
+			array[index] = array[i];
+			array[i] = temp;
+		}
+	}
+
 }

--- a/src/main/java/ch/idsia/crema/utility/RandomUtil.java
+++ b/src/main/java/ch/idsia/crema/utility/RandomUtil.java
@@ -1,12 +1,6 @@
 package ch.idsia.crema.utility;
 
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Ints;
-
-import java.util.Collections;
-import java.util.List;
 import java.util.Random;
-import java.util.stream.DoubleStream;
 
 
 public class RandomUtil {
@@ -17,104 +11,41 @@ public class RandomUtil {
 	 * Sample of vector where the sum of all its elements is 1
 	 *
 	 * @param size
-	 * @param num_decimals
-	 * @param zero_allowed
 	 * @return
 	 */
-	public static double[] sampleNormalized(int size, int num_decimals, boolean zero_allowed) {
+	public static double[] sampleNormalized(int size) {
+		final double[] probs = new double[size];
 
-		int upper = (int) Math.pow(10, num_decimals);
-		if (!zero_allowed)
-			upper -= size;
-
-		double[] data = new double[size];
-		int sum = 0;
-		for (int i = 0; i < size - 1; i++) {
-			if (sum < upper) {
-				int x = random.nextInt(upper - sum);
-				sum += x;
-				data[i] = x;
-			}
-
-		}
-		data[data.length - 1] = ((double) upper - sum);
-
+		double sum = 0;
 		for (int i = 0; i < size; i++) {
-			if (!zero_allowed) {
-				data[i]++;
-				data[i] = data[i] / (upper + size);
-			} else {
-				data[i] = data[i] / upper;
-			}
-		}
-		List<Double> dataList = Doubles.asList(data);
-		Collections.shuffle(dataList, random);
-		return Doubles.toArray(dataList);
-	}
-
-	/**
-	 * Sample an array of itegers from a uniform between 0 and a given upper bound (not included).
-	 *
-	 * @param size        - length of the output
-	 * @param upper_bound - indicates the upper bound of the sampling interval.
-	 * @param sample_all  - allow to constraint that all passible values should appear in the output.
-	 * @return
-	 */
-	public static int[] sampleUniform(int size, int upper_bound, boolean sample_all) {
-
-		if (sample_all && upper_bound > size) {
-			throw new IllegalArgumentException("ERROR: upper_bound cannot be greater than the array size");
+			probs[i] = random.nextDouble();
+			sum += probs[i];
 		}
 
-		int[] data = new int[size];
-
-		int current_i = 0;
-
-		if (sample_all) {
-			for (int i = 0; i < upper_bound; i++)
-				data[i] = i;
-			current_i = upper_bound;
-		}
-		for (int i = current_i; i < size; i++) {
-			data[i] = random.nextInt(upper_bound);
+		double norm = 0;
+		for (int i = 0; i < size - 1; i++) {
+			probs[i] /= sum;
+			norm += probs[i];
 		}
 
-		List<Integer> dataList = Ints.asList(data);
-		Collections.shuffle(dataList, random);
-		return Ints.toArray(dataList);
-	}
+		probs[size - 1] = 1.0 - norm;
+		ArraysUtil.shuffle(probs);
 
-	public static int[] sampleMultinomial(int numCounts, double[] probs) {
-		int num_decimals = DoubleStream.of(probs)
-				.mapToInt(p -> Double.toString(p).split("\\.")[1].length())
-				.max().orElse(10);
-
-		int[] bounds = DoubleStream.of(probs).mapToInt(p -> (int) (Math.round(p * Math.pow(10, num_decimals)))).toArray();
-
-		int acc = 0;
-		for (int i = 0; i < bounds.length; i++) {
-			acc += bounds[i];
-			bounds[i] = acc;
-		}
-
-		int[] S = RandomUtil.sampleUniform(numCounts, (int) Math.pow(10, num_decimals), false);
-
-		int[] counts = new int[probs.length];
-
-		for (int s : S) {
-			for (int i = 0; i < bounds.length; i++) {
-				if (s < bounds[i]) {
-					counts[i]++;
-					break;
-				}
-			}
-		}
-
-		return counts;
+		return probs;
 	}
 
 	public static int sampleCategorical(double[] probs) {
-		return ArraysUtil.where(sampleMultinomial(1, probs), x -> x == 1)[0];
+		final double x = random.nextDouble();
+
+		double sum = 0;
+		for (int i = 0; i < probs.length; i++) {
+			sum += probs[i];
+			if (x < sum) {
+				return i;
+			}
+		}
+
+		return probs.length - 1;
 	}
 
 	public static void setRandom(Random random) {


### PR DESCRIPTION
In certain cases a ```IndexOutOfBound``` exception was raised with the ```RandomUtils.sampleMultinomial()``` method. This was caused by a cumbersome management of such sampling.

Replaced with a more generic, faster, and simpler version.