### PR TITLE
Replacing travis with GitHub actions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,0 +1,50 @@
+name: Java CI with Maven
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          architecture: x64
+
+      - name: Install lpsolve adn polco dependencies
+        run: >
+          mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get
+          -DgroupId=net.sf.lpsolve
+          -DartifactId=lp_solve
+          -Dversion=5.5.2
+          -Dpackaging=jar
+          -DremoteRepositories=https://raw.github.com/idsia/crema/mvn-repo/
+          ;
+          mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get
+          -DgroupId=ch.javasoft.polco
+          -DartifactId=polco
+          -Dversion=4.7.1
+          -Dpackaging=jar
+          -DremoteRepositories=https://raw.github.com/idsia/crema/mvn-repo/
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Execute tests
+        run: mvn test

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'adopt'
           architecture: x64
 
-      - name: Install lpsolve adn polco dependencies
+      - name: Install lpsolve and polco dependencies
         run: >
           mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get
           -DgroupId=net.sf.lpsolve

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: java
-jdk:
-  - openjdk11
-cache:
-  directories:
-    - $HOME/.m2/
-before_install:
-  - mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get -DgroupId=net.sf.lpsolve -DartifactId=lp_solve -Dversion=5.5.2 -Dpackaging=jar -DremoteRepositories=https://raw.github.com/idsia/crema/mvn-repo/
-  - mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get -DgroupId=ch.javasoft.polco -DartifactId=polco -Dversion=4.7.1 -Dpackaging=jar -DremoteRepositories=https://raw.github.com/idsia/crema/mvn-repo/


### PR DESCRIPTION
Added a new workflow for maven test in `.github/workflows/maven.yaml` based on the travis configuration.
Removed the travis configuration file.