### PR TITLE
Noisy-Or multiple fixes

### DIFF
--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianAndFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianAndFactor.java
@@ -60,7 +60,7 @@ public class BayesianAndFactor extends BayesianFunctionFactor {
 		final int[] states = domain.getStatesFor(offset);
 		final int[] vars = domain.getVariables();
 
-		final boolean invert = states[vars[variable]] == 1;
+		final boolean invert = states[ArraysUtil.indexOf(variable, vars)] == 1;
 		final double r_false = invert ? 0.0 : 1.0;
 		final double r_true = invert ? 1.0 : 0.0;
 

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactor.java
@@ -79,7 +79,7 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 			}
 		}
 
-		if (states[vars[variable]] == 1) {
+		if (states[ArraysUtil.indexOf(variable, vars)] == 1) {
 			// P(or = y | ...)
 			return 1 - Q;
 		}

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactor.java
@@ -48,6 +48,20 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 	 */
 	protected int[] observedStates;
 
+	private BayesianNoisyOrFactor(BayesianNoisyOrFactor factor) {
+		super(factor.getDomain());
+		setF(this::f);
+		this.variable = factor.variable;
+		this.parents = ArrayUtils.clone(factor.parents);
+		this.trueStates = ArrayUtils.clone(factor.trueStates);
+		this.inhibitors = ArrayUtils.clone(factor.inhibitors);
+
+		this.isObserved = factor.isObserved;
+		this.isObservedState = factor.isObservedState;
+		this.observedVariables = ArrayUtils.clone(factor.observedVariables);
+		this.observedStates = ArrayUtils.clone(factor.observedStates);
+	}
+
 	/**
 	 * A Noisy OR factor where the true states for each parent are defined externally.
 	 *
@@ -165,7 +179,7 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 
 	@Override
 	public BayesianFactor copy() {
-		return new BayesianNoisyOrFactor(domain, ArrayUtils.clone(parents), ArrayUtils.clone(trueStates), ArrayUtils.clone(inhibitors));
+		return new BayesianNoisyOrFactor(this);
 	}
 
 	@Override

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactor.java
@@ -32,6 +32,23 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 	protected double[] inhibitors;
 
 	/**
+	 * Flag set to true if the variable of this node is observed.
+	 */
+	protected boolean isObserved;
+	/**
+	 * If the flag {@link #isObserved} is set to true, then this field will have the assigned state.
+	 */
+	protected int isObservedState;
+	/**
+	 * Variables that are observed during filtering.
+	 */
+	protected int[] observedVariables;
+	/**
+	 * States of the variables that are observed
+	 */
+	protected int[] observedStates;
+
+	/**
 	 * A Noisy OR factor where the true states for each parent are defined externally.
 	 *
 	 * @param domain     working domain of this factor
@@ -46,6 +63,10 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 		this.parents = parents;
 		this.trueStates = trueStates;
 		this.inhibitors = inhibitors;
+
+		this.isObserved = false;
+		this.observedVariables = new int[0];
+		this.observedStates = new int[0];
 	}
 
 	/**
@@ -57,6 +78,43 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 	 */
 	public BayesianNoisyOrFactor(Strides domain, int[] parents, double[] inhibitors) {
 		this(domain, parents, IntStream.of(parents).map(p -> domain.getCardinality(p) - 1).toArray(), inhibitors);
+	}
+
+	/**
+	 * A Noisy OR factor that has been filtered over the given variable and its state.
+	 *
+	 * @param factor   original factor to filter from
+	 * @param variable filtered variable
+	 * @param state    state of the filtered variable
+	 */
+	protected BayesianNoisyOrFactor(BayesianNoisyOrFactor factor, int variable, int state) {
+		super(factor.getDomain().remove(variable));
+		setF(this::f);
+		this.variable = factor.variable;
+		this.parents = ArrayUtils.clone(factor.parents);
+		this.trueStates = ArrayUtils.clone(factor.trueStates);
+		this.inhibitors = ArrayUtils.clone(factor.inhibitors);
+
+		// update internal observed variables state
+		this.isObserved = variable == this.variable;
+
+		if (this.isObserved) {
+			// variable is the node itself
+			this.isObservedState = state;
+
+			this.observedVariables = ArrayUtils.clone(factor.observedVariables);
+			this.observedStates = ArrayUtils.clone(factor.observedStates);
+		} else {
+			// variable is a parent
+			this.observedVariables = new int[factor.observedVariables.length + 1];
+			this.observedStates = new int[factor.observedStates.length + 1];
+
+			System.arraycopy(factor.observedVariables, 0, this.observedVariables, 0, factor.observedVariables.length);
+			System.arraycopy(factor.observedStates, 0, this.observedStates, 0, factor.observedStates.length);
+
+			this.observedVariables[this.observedVariables.length - 1] = variable;
+			this.observedStates[this.observedStates.length - 1] = state;
+		}
 	}
 
 	/**
@@ -79,10 +137,28 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 			}
 		}
 
-		if (states[ArraysUtil.indexOf(variable, vars)] == 1) {
+		// inhibitor value of observed parents
+		for (int v : observedVariables) {
+			final int x = ArraysUtil.indexOf(v, observedVariables);
+			final int p = ArraysUtil.indexOf(v, parents);
+			if (x > -1 && p > -1 && observedStates[x] == trueStates[p]) {
+				Q *= inhibitors[p];
+			}
+		}
+
+		// output if the node has evidence
+		if (isObserved && isObservedState == 1)
 			// P(or = y | ...)
 			return 1 - Q;
-		}
+		if (isObserved)
+			// P(or = n | ...)
+			return Q;
+
+		// output if the node has no evidence
+		if (states[ArraysUtil.indexOf(variable, vars)] == 1)
+			// P(or = y | ...)
+			return 1 - Q;
+
 		// P(or = n | ...)
 		return Q;
 	}
@@ -94,21 +170,14 @@ public class BayesianNoisyOrFactor extends BayesianFunctionFactor {
 
 	@Override
 	public BayesianAbstractFactor filter(int variable, int state) {
-		// TODO: is this still valid for noisy-or?
 		final int p = ArraysUtil.indexOf(variable, parents);
 
-		if (p > -1 && trueStates[p] == state)
-			return BayesianFactorFactory.one(this.variable);
-
 		if (p > -1 && trueStates[p] != state && parents.length == 1)
+			// last parents' state is off
 			return BayesianFactorFactory.zero(this.variable);
 
-		return new BayesianNoisyOrFactor(
-				getDomain().remove(variable),
-				ArrayUtils.remove(parents, p),
-				ArrayUtils.remove(trueStates, p),
-				ArrayUtils.remove(inhibitors, p)
-		);
+		// parent or variable is observed
+		return new BayesianNoisyOrFactor(this, variable, state);
 	}
 
 	@Override

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianOrFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianOrFactor.java
@@ -60,7 +60,7 @@ public class BayesianOrFactor extends BayesianFunctionFactor {
 		final int[] states = domain.getStatesFor(offset);
 		final int[] vars = domain.getVariables();
 
-		final boolean invert = states[vars[variable]] == 1;
+		final boolean invert = states[ArraysUtil.indexOf(variable, vars)] == 1;
 		final double r_true = invert ? 1.0 : 0.0;
 		final double r_false = invert ? 0.0 : 1.0;
 

--- a/src/test/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactorTest.java
+++ b/src/test/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactorTest.java
@@ -68,15 +68,6 @@ class BayesianNoisyOrFactorTest {
 	}
 
 	@Test
-	void testFilterToOne() {
-		final BayesianFactor o = new BayesianNoisyOrFactor(DomainBuilder.var(1, 2).size(2, 2).strides(), new int[]{1}, new double[]{.1});
-		final BayesianFactor b = o.filter(1, 1);
-		final BayesianFactor one = BayesianFactorFactory.one(2);
-
-		Assertions.assertEquals(one, b);
-	}
-
-	@Test
 	void testFilterToZero() {
 		final BayesianFactor o = new BayesianNoisyOrFactor(DomainBuilder.var(1, 2).size(2, 2).strides(), new int[]{1}, new double[]{.3});
 		final BayesianFactor a = o.filter(1, 0);
@@ -97,17 +88,24 @@ class BayesianNoisyOrFactorTest {
 		final BayesianFactor aa = a.filter(2, 1);
 		final BayesianFactor bb = b.filter(1, 1);
 
-		final BayesianFactor one = BayesianFactorFactory.one(3);
-		final BayesianFactor zero = BayesianFactorFactory.zero(3);
+		Assertions.assertEquals(.3, c.getValue(0, 0));
+		Assertions.assertEquals(.7, c.getValue(0, 1));
+		Assertions.assertEquals(.12, c.getValue(1, 0));
+		Assertions.assertEquals(.88, c.getValue(1, 1));
 
-		Assertions.assertEquals(one, aa);
-		Assertions.assertEquals(one, bb);
-		Assertions.assertEquals(one, c);
-		Assertions.assertEquals(one, d);
-		Assertions.assertEquals(zero, e);
+		Assertions.assertEquals(.4, aa.getValue(0));
+		Assertions.assertEquals(.3, bb.getValue(0));
+
+		Assertions.assertEquals(2, aa.getDomain().getSizes()[0]);
+		Assertions.assertEquals(2, bb.getDomain().getSizes()[0]);
 
 		Assertions.assertTrue(a instanceof BayesianNoisyOrFactor);
 		Assertions.assertTrue(b instanceof BayesianNoisyOrFactor);
+		Assertions.assertTrue(c instanceof BayesianNoisyOrFactor);
+		Assertions.assertTrue(d instanceof BayesianNoisyOrFactor);
+		Assertions.assertTrue(e instanceof BayesianNoisyOrFactor);
+		Assertions.assertTrue(aa instanceof BayesianNoisyOrFactor);
+		Assertions.assertTrue(bb instanceof BayesianNoisyOrFactor);
 	}
 
 	@Test


### PR DESCRIPTION
* Fixed an issue in `BayesianAndFactor`, `BayesianOrFactor`, and `BayesianNoisyOrFactor` that happens when there is a discontinuity in the parent variables values.
* Fixed an issue with `BayesianNoisyOrFactor` caused by filter method.
* Fixed `BayesianNoisyOrFactor` copy method.
* Fixed `BayesianNoisyOrFactor` and tests.