### PR TITLE
Fixes for BayesianLogicFactors

### DIFF
--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianAndFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianAndFactor.java
@@ -5,27 +5,13 @@ import ch.idsia.crema.utility.ArraysUtil;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
-import java.util.stream.IntStream;
 
 /**
  * Author:  Claudio "Dna" Bonesana
  * Project: crema
  * Date:    23.08.2021 14:40
  */
-public class BayesianAndFactor extends BayesianFunctionFactor {
-
-	/**
-	 * Variables defined on this factor (not parents).
-	 */
-	protected int variable;
-	/**
-	 * Variables that are parents.
-	 */
-	protected int[] parents;
-	/**
-	 * Value of the TRUE state for each parent.
-	 */
-	protected int[] trueStates;
+public class BayesianAndFactor extends BayesianLogicFactor {
 
 	/**
 	 * An AND factor where the true states for each parent are defined externally.
@@ -35,11 +21,7 @@ public class BayesianAndFactor extends BayesianFunctionFactor {
 	 * @param trueStates index of the state to be considered as TRUE for each given parent
 	 */
 	public BayesianAndFactor(Strides domain, int[] parents, int[] trueStates) {
-		super(domain);
-		setF(this::f);
-		this.variable = ArraysUtil.difference(domain.getVariables(), parents)[0];
-		this.parents = parents;
-		this.trueStates = trueStates;
+		super(domain, parents, trueStates);
 	}
 
 	/**
@@ -49,20 +31,55 @@ public class BayesianAndFactor extends BayesianFunctionFactor {
 	 * @param parents variables that are parents of this factor
 	 */
 	public BayesianAndFactor(Strides domain, int... parents) {
-		this(domain, parents, IntStream.of(parents).map(p -> domain.getCardinality(p) - 1).toArray());
+		super(domain, parents);
+	}
+
+	/**
+	 * An AND factor where one variable has been filtered out (used internally during filter).
+	 *
+	 * @param factor   the original factor
+	 * @param variable the variable to remove
+	 * @param state    the state of the variable to remove
+	 */
+	protected BayesianAndFactor(BayesianAndFactor factor, int variable, int state) {
+		super(factor, variable, state);
+	}
+
+	/**
+	 * Copy constructor.
+	 *
+	 * @param factor factor to copy from
+	 */
+	private BayesianAndFactor(BayesianAndFactor factor) {
+		super(factor);
 	}
 
 	/**
 	 * @param offset offset to get the value for
 	 * @return 0.0 when at least one of the parents is in the FALSE state, otherwise 1.0
 	 */
+	@Override
 	protected double f(int offset) {
 		final int[] states = domain.getStatesFor(offset);
 		final int[] vars = domain.getVariables();
 
-		final boolean invert = states[ArraysUtil.indexOf(variable, vars)] == 1;
+		final boolean invert;
+		if (isObserved) {
+			invert = observedState == 1;
+		} else {
+			invert = states[ArraysUtil.indexOf(variable, vars)] == 1;
+		}
+
 		final double r_false = invert ? 0.0 : 1.0;
 		final double r_true = invert ? 1.0 : 0.0;
+
+		// if one of the observed variables is a parent and its state is false, return false
+		for (int v : observedVariables) {
+			final int x = ArraysUtil.indexOf(v, observedVariables);
+			final int p = ArraysUtil.indexOf(v, parents);
+			if (x > -1 && p > -1 && observedStates[x] != trueStates[p])
+				return r_false;
+		}
 
 		for (int i = 0; i < vars.length; i++) {
 			final int v = vars[i];
@@ -78,7 +95,7 @@ public class BayesianAndFactor extends BayesianFunctionFactor {
 
 	@Override
 	public BayesianFactor copy() {
-		return new BayesianAndFactor(domain, ArrayUtils.clone(parents), ArrayUtils.clone(trueStates));
+		return new BayesianAndFactor(this);
 	}
 
 	@Override
@@ -88,10 +105,11 @@ public class BayesianAndFactor extends BayesianFunctionFactor {
 		if (p > -1 && trueStates[p] != state)
 			return BayesianFactorFactory.zero(this.variable);
 
-		if (p > -1 && trueStates[p] == state && parents.length == 1)
+		// check for last parent
+		if (p > -1 && trueStates[p] == state && parents.length - observedVariables.length == 1)
 			return BayesianFactorFactory.one(this.variable);
 
-		return new BayesianAndFactor(getDomain().remove(variable), ArrayUtils.remove(parents, p), ArrayUtils.remove(trueStates, p));
+		return new BayesianAndFactor(this, variable, state);
 	}
 
 	@Override

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianFactorFactory.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianFactorFactory.java
@@ -222,4 +222,176 @@ public class BayesianFactorFactory {
 		return new BayesianDefaultFactor(new Strides(vars, sizes), d);
 	}
 
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param parent variable that is the parent of this factor
+	 * @return a logic {@link BayesianNotFactor}
+	 */
+	public BayesianNotFactor not(int parent) {
+		return new BayesianNotFactor(domain, parent);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param parent    variable that is the parent of this factor
+	 * @param trueState index of the state to be considered as TRUE for the given parent
+	 * @return a logic {@link BayesianAndFactor}
+	 */
+	public BayesianAndFactor not(int parent, int trueState) {
+		return new BayesianAndFactor(domain, parent, trueState);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param parents variables that are parents of this factor
+	 * @return a logic {@link BayesianAndFactor}
+	 */
+	public BayesianAndFactor and(int... parents) {
+		// sort variables
+		final int[] vars = ArraysUtil.sort(domain.getVariables());
+		final int[] sizes = IntStream.of(vars).map(domain::indexOf).map(domain::getSizeAt).toArray();
+		final int[] order = ArraysUtil.order(parents);
+
+		// sort parents
+		final int[] pars = new int[parents.length];
+
+		for (int i = 0; i < order.length; i++) {
+			int o = order[i];
+			pars[i] = parents[o];
+		}
+		return new BayesianAndFactor(new Strides(vars, sizes), pars);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param trueStates index of the state to be considered as TRUE for each given parent
+	 * @param parents    variables that are parents of this factor
+	 * @return a logic {@link BayesianAndFactor}
+	 */
+	public BayesianAndFactor and(int[] parents, int[] trueStates) {
+		// sort variables
+		final int[] vars = ArraysUtil.sort(domain.getVariables());
+		final int[] sizes = IntStream.of(vars).map(domain::indexOf).map(domain::getSizeAt).toArray();
+		final int[] order = ArraysUtil.order(parents);
+
+		// sort parents
+		final int[] pars = new int[parents.length];
+		final int[] trus = new int[trueStates.length];
+
+		for (int i = 0; i < order.length; i++) {
+			int o = order[i];
+			pars[i] = parents[o];
+			trus[i] = trueStates[o];
+		}
+
+		return new BayesianAndFactor(new Strides(vars, sizes), pars, trus);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param parents variables that are parents of this factor
+	 * @return a logic {@link BayesianOrFactor}
+	 */
+	public BayesianOrFactor or(int... parents) {
+		// sort variables
+		final int[] vars = ArraysUtil.sort(domain.getVariables());
+		final int[] sizes = IntStream.of(vars).map(domain::indexOf).map(domain::getSizeAt).toArray();
+		final int[] order = ArraysUtil.order(parents);
+
+		// sort parents
+		final int[] pars = new int[parents.length];
+
+		for (int i = 0; i < order.length; i++) {
+			int o = order[i];
+			pars[i] = parents[o];
+		}
+		return new BayesianOrFactor(new Strides(vars, sizes), pars);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param trueStates index of the state to be considered as TRUE for each given parent
+	 * @param parents    variables that are parents of this factor
+	 * @return a logic {@link BayesianOrFactor}
+	 */
+	public BayesianOrFactor or(int[] parents, int[] trueStates) {
+		// sort variables
+		final int[] vars = ArraysUtil.sort(domain.getVariables());
+		final int[] sizes = IntStream.of(vars).map(domain::indexOf).map(domain::getSizeAt).toArray();
+		final int[] order = ArraysUtil.order(parents);
+
+		// sort parents
+		final int[] pars = new int[parents.length];
+		final int[] trus = new int[trueStates.length];
+
+		for (int i = 0; i < order.length; i++) {
+			int o = order[i];
+			pars[i] = parents[o];
+			trus[i] = trueStates[o];
+		}
+
+		return new BayesianOrFactor(new Strides(vars, sizes), pars, trus);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param parents    variables that are parents of this factor
+	 * @param inhibitors values for the noise for each given parent
+	 * @return a logic {@link BayesianNoisyOrFactor}
+	 */
+	public BayesianNoisyOrFactor noisyOr(int[] parents, double[] inhibitors) {
+		// sort variables
+		final int[] vars = ArraysUtil.sort(domain.getVariables());
+		final int[] sizes = IntStream.of(vars).map(domain::indexOf).map(domain::getSizeAt).toArray();
+		final int[] order = ArraysUtil.order(parents);
+
+		// sort parents
+		final int[] pars = new int[parents.length];
+		final double[] inbs = new double[inhibitors.length];
+
+		for (int i = 0; i < order.length; i++) {
+			int o = order[i];
+			pars[i] = parents[o];
+			inbs[i] = inhibitors[o];
+		}
+
+		return new BayesianNoisyOrFactor(new Strides(vars, sizes), pars, inbs);
+	}
+
+	/**
+	 * Requires a pre-defined Domain.
+	 *
+	 * @param parents    variables that are parents of this factor
+	 * @param trueStates index of the state to be considered as TRUE for each given parent
+	 * @param inhibitors values for the noise for each given parent
+	 * @return a logic {@link BayesianNoisyOrFactor}
+	 */
+	public BayesianNoisyOrFactor noisyOr(int[] parents, int[] trueStates, double[] inhibitors) {
+		// sort variables
+		final int[] vars = ArraysUtil.sort(domain.getVariables());
+		final int[] sizes = IntStream.of(vars).map(domain::indexOf).map(domain::getSizeAt).toArray();
+		final int[] order = ArraysUtil.order(parents);
+
+		// sort parents
+		final int[] pars = new int[parents.length];
+		final int[] trus = new int[trueStates.length];
+		final double[] inbs = new double[inhibitors.length];
+
+		for (int i = 0; i < order.length; i++) {
+			int o = order[i];
+			pars[i] = parents[o];
+			trus[i] = trueStates[o];
+			inbs[i] = inhibitors[o];
+		}
+
+		return new BayesianNoisyOrFactor(new Strides(vars, sizes), pars, trus, inbs);
+	}
+
 }

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianLogicFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianLogicFactor.java
@@ -1,0 +1,138 @@
+package ch.idsia.crema.factor.bayesian;
+
+import ch.idsia.crema.core.Strides;
+import ch.idsia.crema.utility.ArraysUtil;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.stream.IntStream;
+
+/**
+ * Author:  Claudio "Dna" Bonesana
+ * Project: crema
+ * Date:    30.09.2021 11:22
+ */
+public abstract class BayesianLogicFactor extends BayesianFunctionFactor {
+
+	/**
+	 * Variables defined on this factor (not parents).
+	 */
+	protected int variable;
+	/**
+	 * Variables that are parents.
+	 */
+	protected int[] parents;
+	/**
+	 * Value of the TRUE state for each parent.
+	 */
+	protected int[] trueStates;
+
+	/**
+	 * Flag set to true if the variable of this node is observed.
+	 */
+	protected boolean isObserved;
+	/**
+	 * If the flag {@link #isObserved} is set to true, then this field will have the assigned state.
+	 */
+	protected int observedState;
+	/**
+	 * Variables that are observed during filtering.
+	 */
+	protected int[] observedVariables;
+	/**
+	 * States of the variables that are observed
+	 */
+	protected int[] observedStates;
+
+
+	/**
+	 * A logic factor where the true states for each parent are defined externally.
+	 *
+	 * @param domain     working domain of this factor
+	 * @param parents    variables that are parents of this factor
+	 * @param trueStates index of the state to be considered as TRUE for each given parent
+	 */
+	public BayesianLogicFactor(Strides domain, int[] parents, int[] trueStates) {
+		super(domain);
+		setF(this::f);
+		this.variable = ArraysUtil.difference(domain.getVariables(), parents)[0];
+		this.parents = parents;
+		this.trueStates = trueStates;
+
+		this.isObserved = false;
+		this.observedVariables = new int[0];
+		this.observedStates = new int[0];
+	}
+
+	/**
+	 * A logic factor where the true state for each parent is the higher state available.
+	 *
+	 * @param domain  working domain of this factor
+	 * @param parents variables that are parents of this factor
+	 */
+	public BayesianLogicFactor(Strides domain, int... parents) {
+		this(domain, parents, IntStream.of(parents).map(p -> domain.getCardinality(p) - 1).toArray());
+	}
+
+	/**
+	 * A logic factor where one variable has been filtered out (can be used during filter).
+	 *
+	 * @param factor   the original factor
+	 * @param variable the variable to remove
+	 * @param state    the state of the variable to remove
+	 */
+	protected BayesianLogicFactor(BayesianLogicFactor factor, int variable, int state) {
+		super(factor.getDomain().remove(variable));
+		setF(this::f);
+		this.variable = factor.variable;
+		this.parents = ArrayUtils.clone(factor.parents);
+		this.trueStates = ArrayUtils.clone(factor.trueStates);
+
+		// update internal observed variables state
+		this.isObserved = variable == this.variable;
+
+		if (this.isObserved) {
+			// variable is the node itself
+			this.observedState = state;
+
+			this.observedVariables = ArrayUtils.clone(factor.observedVariables);
+			this.observedStates = ArrayUtils.clone(factor.observedStates);
+		} else {
+			// variable is a parent
+			this.observedVariables = new int[factor.observedVariables.length + 1];
+			this.observedStates = new int[factor.observedStates.length + 1];
+
+			System.arraycopy(factor.observedVariables, 0, this.observedVariables, 0, factor.observedVariables.length);
+			System.arraycopy(factor.observedStates, 0, this.observedStates, 0, factor.observedStates.length);
+
+			this.observedVariables[this.observedVariables.length - 1] = variable;
+			this.observedStates[this.observedStates.length - 1] = state;
+		}
+	}
+
+	/**
+	 * Copy constructor.
+	 *
+	 * @param factor factor to copy from
+	 */
+	protected BayesianLogicFactor(BayesianLogicFactor factor) {
+		super(factor.getDomain());
+		setF(this::f);
+		this.variable = factor.variable;
+		this.parents = ArrayUtils.clone(factor.parents);
+		this.trueStates = ArrayUtils.clone(factor.trueStates);
+
+		this.isObserved = factor.isObserved;
+		this.observedState = factor.observedState;
+		this.observedVariables = ArrayUtils.clone(factor.observedVariables);
+		this.observedStates = ArrayUtils.clone(factor.observedStates);
+	}
+
+	/**
+	 * The function that implements the logic of this factor.
+	 *
+	 * @param i the offset of the CPT already computed by the external algorithm
+	 * @return the value associated with the given offset
+	 */
+	abstract double f(int i);
+
+}

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNotFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianNotFactor.java
@@ -25,6 +25,7 @@ public class BayesianNotFactor extends BayesianFunctionFactor {
 	 */
 	protected int trueState;
 
+
 	protected BayesianNotFactor(Strides domain, int parent, int trueState) {
 		super(domain);
 		if (domain.getVariables().length > 2)
@@ -37,6 +38,11 @@ public class BayesianNotFactor extends BayesianFunctionFactor {
 
 	public BayesianNotFactor(Strides domain, int parent) {
 		this(domain, parent, domain.getCardinality(parent) - 1);
+	}
+
+	private BayesianNotFactor(BayesianNotFactor factor) {
+		this(factor.getDomain(), factor.parent, factor.trueState);
+		this.variable = factor.variable;
 	}
 
 	protected double f(int offset) {
@@ -54,7 +60,7 @@ public class BayesianNotFactor extends BayesianFunctionFactor {
 
 	@Override
 	public BayesianFactor copy() {
-		return new BayesianNotFactor(getDomain(), parent, trueState);
+		return new BayesianNotFactor(this);
 	}
 
 	@Override

--- a/src/main/java/ch/idsia/crema/factor/bayesian/BayesianOrFactor.java
+++ b/src/main/java/ch/idsia/crema/factor/bayesian/BayesianOrFactor.java
@@ -5,27 +5,13 @@ import ch.idsia.crema.utility.ArraysUtil;
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
-import java.util.stream.IntStream;
 
 /**
  * Author:  Claudio "Dna" Bonesana
  * Project: crema
  * Date:    16.08.2021 15:33
  */
-public class BayesianOrFactor extends BayesianFunctionFactor {
-
-	/**
-	 * Variables defined on this factor (not parents).
-	 */
-	protected int variable;
-	/**
-	 * Variables that are parents.
-	 */
-	protected int[] parents;
-	/**
-	 * Value of the TRUE state for each parent.
-	 */
-	protected int[] trueStates;
+public class BayesianOrFactor extends BayesianLogicFactor {
 
 	/**
 	 * An OR factor where the true states for each parent are defined externally.
@@ -35,11 +21,7 @@ public class BayesianOrFactor extends BayesianFunctionFactor {
 	 * @param trueStates index of the state to be considered as TRUE for each given parent
 	 */
 	public BayesianOrFactor(Strides domain, int[] parents, int[] trueStates) {
-		super(domain);
-		setF(this::f);
-		this.variable = ArraysUtil.difference(domain.getVariables(), parents)[0];
-		this.parents = parents;
-		this.trueStates = trueStates;
+		super(domain, parents, trueStates);
 	}
 
 	/**
@@ -49,20 +31,48 @@ public class BayesianOrFactor extends BayesianFunctionFactor {
 	 * @param parents variables that are parents of this factor
 	 */
 	public BayesianOrFactor(Strides domain, int... parents) {
-		this(domain, parents, IntStream.of(parents).map(p -> domain.getCardinality(p) - 1).toArray());
+		super(domain, parents);
+	}
+
+	protected BayesianOrFactor(BayesianOrFactor factor, int variable, int state) {
+		super(factor, variable, state);
+	}
+
+	/**
+	 * Copy constructor.
+	 *
+	 * @param factor factor to copy from
+	 */
+	private BayesianOrFactor(BayesianOrFactor factor) {
+		super(factor);
 	}
 
 	/**
 	 * @param offset offset to get the value for
 	 * @return 1.0 when at least one of the parents is in the TRUE state, otherwise 0.0
 	 */
+	@Override
 	protected double f(int offset) {
 		final int[] states = domain.getStatesFor(offset);
 		final int[] vars = domain.getVariables();
 
-		final boolean invert = states[ArraysUtil.indexOf(variable, vars)] == 1;
+		final boolean invert;
+		if (isObserved) {
+			invert = observedState == 1;
+		} else {
+			invert = states[ArraysUtil.indexOf(variable, vars)] == 1;
+		}
+
 		final double r_true = invert ? 1.0 : 0.0;
 		final double r_false = invert ? 0.0 : 1.0;
+
+		// if one of the observed variables is a parent and its state is true, return true
+		for (int v : observedVariables) {
+			final int x = ArraysUtil.indexOf(v, observedVariables);
+			final int p = ArraysUtil.indexOf(v, parents);
+			if (x > -1 && p > -1 && observedStates[x] != trueStates[p])
+				return r_true;
+		}
 
 		for (int i = 0; i < vars.length; i++) {
 			final int v = vars[i];
@@ -78,7 +88,7 @@ public class BayesianOrFactor extends BayesianFunctionFactor {
 
 	@Override
 	public BayesianFactor copy() {
-		return new BayesianOrFactor(domain, ArrayUtils.clone(parents), ArrayUtils.clone(trueStates));
+		return new BayesianOrFactor(this);
 	}
 
 	@Override
@@ -88,10 +98,11 @@ public class BayesianOrFactor extends BayesianFunctionFactor {
 		if (p > -1 && trueStates[p] == state)
 			return BayesianFactorFactory.one(this.variable);
 
-		if (p > -1 && trueStates[p] != state && parents.length == 1)
+		// check for last parent
+		if (p > -1 && trueStates[p] != state && parents.length - observedVariables.length == 1)
 			return BayesianFactorFactory.zero(this.variable);
 
-		return new BayesianOrFactor(getDomain().remove(variable), ArrayUtils.remove(parents, p), ArrayUtils.remove(trueStates, p));
+		return new BayesianOrFactor(this, variable, state);
 	}
 
 	@Override

--- a/src/test/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactorTest.java
+++ b/src/test/java/ch/idsia/crema/factor/bayesian/BayesianNoisyOrFactorTest.java
@@ -88,6 +88,8 @@ class BayesianNoisyOrFactorTest {
 		final BayesianFactor aa = a.filter(2, 1);
 		final BayesianFactor bb = b.filter(1, 1);
 
+		final BayesianFactor zero = BayesianFactorFactory.zero(3);
+
 		Assertions.assertEquals(.3, c.getValue(0, 0));
 		Assertions.assertEquals(.7, c.getValue(0, 1));
 		Assertions.assertEquals(.12, c.getValue(1, 0));
@@ -99,11 +101,12 @@ class BayesianNoisyOrFactorTest {
 		Assertions.assertEquals(2, aa.getDomain().getSizes()[0]);
 		Assertions.assertEquals(2, bb.getDomain().getSizes()[0]);
 
+		Assertions.assertEquals(zero, e);
+
 		Assertions.assertTrue(a instanceof BayesianNoisyOrFactor);
 		Assertions.assertTrue(b instanceof BayesianNoisyOrFactor);
 		Assertions.assertTrue(c instanceof BayesianNoisyOrFactor);
 		Assertions.assertTrue(d instanceof BayesianNoisyOrFactor);
-		Assertions.assertTrue(e instanceof BayesianNoisyOrFactor);
 		Assertions.assertTrue(aa instanceof BayesianNoisyOrFactor);
 		Assertions.assertTrue(bb instanceof BayesianNoisyOrFactor);
 	}


### PR DESCRIPTION
An addendum to #92

* create a new abstract class `BayesianLogicFactor` that is extended by `BayesianAndFactor`, `BayesianOrFactor`, and `BayesianNoisyOrFactor` (`BayesianNotFactor` left out since it is a unary operation).
* Fixed multiple issues with filtering of `BayesianLogicFactor` factors.
* Added possibility to create `BayesianLogicFactor` from the `BayesianFactorFactory` utility class.