### PR TITLE
Lambda for RandomUtil.getRandom()

### DIFF
--- a/src/main/java/ch/idsia/crema/utility/RandomUtil.java
+++ b/src/main/java/ch/idsia/crema/utility/RandomUtil.java
@@ -51,19 +51,48 @@ public class RandomUtil {
 		return probs.length - 1;
 	}
 
+	/**
+	 * Set a new {@link #random} object to use and reset the supplier function to the original one.
+	 *
+	 * @param random the {@link Random} object to use.
+	 */
 	public static void setRandom(Random random) {
 		RandomUtil.random = random;
+		setRandom(() -> random);
 	}
 
+	/**
+	 * Change the current {@link #supplier} function with a new one.
+	 * <p>
+	 * Note that <b>ALL</b> future call to the {@link #getRandom()} method will use this function!
+	 *
+	 * @param random new supplier of {@link Random} objects
+	 */
 	public static void setRandom(Supplier<Random> random) {
 		supplier = random;
 	}
 
+	/**
+	 * Change the current {@link #random} object with a new random initialized with the given seed.
+	 *
+	 * @param seed new random seed to use
+	 */
 	public static void setRandomSeed(long seed) {
 		setRandom(new Random(seed));
 	}
 
+	/**
+	 * @return a {@link Random} object based on the current {@link #supplier} function.
+	 */
 	public static Random getRandom() {
 		return supplier.get();
 	}
+
+	/**
+	 * Set the {@link #supplier} function back to the original one.
+	 */
+	public static void reset() {
+		setRandom(() -> random);
+	}
+
 }

--- a/src/main/java/ch/idsia/crema/utility/RandomUtil.java
+++ b/src/main/java/ch/idsia/crema/utility/RandomUtil.java
@@ -1,11 +1,14 @@
 package ch.idsia.crema.utility;
 
 import java.util.Random;
+import java.util.function.Supplier;
 
 
 public class RandomUtil {
 
 	private static Random random = new Random(1234);
+
+	private static Supplier<Random> supplier = () -> random;
 
 	/**
 	 * Sample of vector where the sum of all its elements is 1
@@ -18,7 +21,7 @@ public class RandomUtil {
 
 		double sum = 0;
 		for (int i = 0; i < size; i++) {
-			probs[i] = random.nextDouble();
+			probs[i] = getRandom().nextDouble();
 			sum += probs[i];
 		}
 
@@ -35,7 +38,7 @@ public class RandomUtil {
 	}
 
 	public static int sampleCategorical(double[] probs) {
-		final double x = random.nextDouble();
+		final double x = getRandom().nextDouble();
 
 		double sum = 0;
 		for (int i = 0; i < probs.length; i++) {
@@ -52,11 +55,15 @@ public class RandomUtil {
 		RandomUtil.random = random;
 	}
 
+	public static void setRandom(Supplier<Random> random) {
+		supplier = random;
+	}
+
 	public static void setRandomSeed(long seed) {
 		setRandom(new Random(seed));
 	}
 
 	public static Random getRandom() {
-		return random;
+		return supplier.get();
 	}
 }

--- a/src/test/java/ch/idsia/crema/utility/RandomUtilTest.java
+++ b/src/test/java/ch/idsia/crema/utility/RandomUtilTest.java
@@ -42,16 +42,19 @@ class RandomUtilTest {
 	void testConcurrentRandomExecution() throws Exception {
 		final ExecutorService es = Executors.newFixedThreadPool(2);
 
-		final Map<String, Random> randoms = new ConcurrentHashMap<>();
+		final Map<String, Random> randoms = new ConcurrentHashMap<>(Map.of(
+				"Thread0", new Random(0),
+				"Thread1", new Random(1),
+				"Thread2", new Random(0),
+				"Thread3", new Random(1)
+		));
 
 		RandomUtil.setRandom(() -> randoms.get(Thread.currentThread().getName()));
 
 		final List<Callable<int[]>> tasks = IntStream.range(0, 4)
 				.mapToObj(i -> (Callable<int[]>) () -> {
-					final int seed = i % 2;
-					final String tName = "Thread" + seed;
+					final String tName = "Thread" + i;
 					Thread.currentThread().setName(tName);
-					randoms.put(tName, new Random(seed));
 
 					return IntStream.generate(() -> RandomUtil.getRandom().nextInt(10))
 							.limit(10)

--- a/src/test/java/ch/idsia/crema/utility/RandomUtilTest.java
+++ b/src/test/java/ch/idsia/crema/utility/RandomUtilTest.java
@@ -1,5 +1,6 @@
 package ch.idsia.crema.utility;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +17,11 @@ import java.util.stream.IntStream;
  * Date:    06.10.2021 10:24
  */
 class RandomUtilTest {
+
+	@AfterEach
+	void tearDown() {
+		RandomUtil.reset();
+	}
 
 	@Test
 	void testRandomSupplier() {

--- a/src/test/java/ch/idsia/crema/utility/RandomUtilTest.java
+++ b/src/test/java/ch/idsia/crema/utility/RandomUtilTest.java
@@ -1,0 +1,68 @@
+package ch.idsia.crema.utility;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Author:  Claudio "Dna" Bonesana
+ * Project: crema
+ * Date:    06.10.2021 10:24
+ */
+class RandomUtilTest {
+
+	@Test
+	void testRandomSupplier() {
+
+		final Random r1 = new Random(1); // first nextInt(): -1155869325
+		final Random r2 = new Random(2); // first nextInt(): -1154715079
+
+		RandomUtil.setRandom(r1);
+
+		Assertions.assertEquals(-1155869325, RandomUtil.getRandom().nextInt());
+
+		RandomUtil.setRandom(() -> r2);
+
+		Assertions.assertEquals(-1154715079, RandomUtil.getRandom().nextInt());
+	}
+
+	@Test
+	void testConcurrentRandomExecution() throws Exception {
+		final ExecutorService es = Executors.newFixedThreadPool(2);
+
+		final Map<String, Random> randoms = new ConcurrentHashMap<>();
+
+		RandomUtil.setRandom(() -> randoms.get(Thread.currentThread().getName()));
+
+		final List<Callable<int[]>> tasks = IntStream.range(0, 4)
+				.mapToObj(i -> (Callable<int[]>) () -> {
+					final int seed = i % 2;
+					final String tName = "Thread" + seed;
+					Thread.currentThread().setName(tName);
+					randoms.put(tName, new Random(seed));
+
+					return IntStream.generate(() -> RandomUtil.getRandom().nextInt(10))
+							.limit(10)
+							.toArray();
+				})
+				.collect(Collectors.toList());
+
+		final List<Future<int[]>> futures = es.invokeAll(tasks);
+
+		es.shutdown();
+
+		final int[] seq0 = futures.get(0).get();
+		final int[] seq1 = futures.get(1).get();
+		final int[] seq2 = futures.get(2).get();
+		final int[] seq3 = futures.get(3).get();
+
+		Assertions.assertArrayEquals(seq0, seq2);
+		Assertions.assertArrayEquals(seq1, seq3);
+	}
+}


### PR DESCRIPTION
Using crema in a concurrent environment has some issue, like the impossibility to run parallel code that uses the `RandomUtil` class.

In order to help mitigate this issue a new *static* method was added to the `RandomUtil` class: `setRandom(Supplier<Random> random)`.

This method allows to change how the method `getRandom()` returns the static random number generator instance. The default behavior is to have the usual behavior of the class prior to this change.

With this method is now possible to use manage externally which random to use for each concurrent execution of crema's code in a controlled environment. An example is the following:

```java
// we initialize a ConcurrentHashMap with the Random objec to use in each thread
final Map<String, Random> randoms = new ConcurrentHashMap<>(Map.of(
	"Thread0", new Random(0),
	"Thread1", new Random(1),
	"Thread2", new Random(0),
	"Thread3", new Random(1)
));

// to get the random to use, get current thread's name from the above map
RandomUtil.setRandom(() -> randoms.get(Thread.currentThread().getName()));

final List<Callable<int[]>> tasks = IntStream.range(0, 4)
	.mapToObj(i -> (Callable<int[]>) () -> {
		// set a name for the thread based, as an example, on the used seed
		final String tName = "Thread" + i;
		Thread.currentThread().setName(tName);

		// put on the map a new random with the thread's name
		randoms.put(tName, new Random(seed));

		// the supplier defined above will return the random based on the name of the current thread
		// so in this thread crema's will always use the same random number generator, also defined in the task
		return IntStream.generate(() -> RandomUtil.getRandom().nextInt(10))
				.limit(10)
				.toArray();
	})
	.collect(Collectors.toList());
```

This example was extracted from the `RandomUtilTest#testConcurrentRandomExecution()` test case.

To restore the original supplier function use the `RandomUtil.reset()` method.
