### PR TITLE
Fixed issue with disjoint graph and LoopyBeliefPropagation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 0.2.2-SNAPSHOT
 ===========
 
-
+- Added new *logic* Bayesian factor `BayesianNoisyAndFactor`
+- Fixed an issue with LoopyBeliefPropagation and disjoint graphs.
 
 0.2.2
 ===========

--- a/src/main/java/ch/idsia/crema/inference/bp/LoopyBeliefPropagation.java
+++ b/src/main/java/ch/idsia/crema/inference/bp/LoopyBeliefPropagation.java
@@ -248,7 +248,7 @@ public class LoopyBeliefPropagation<F extends OperableFactor<F>> implements Infe
 
 	private F variableMarginal(int query) {
 		F v = model.getFactor(query);
-		if (!graph.edgeSet().isEmpty()) {
+		if (!graph.edgeSet().isEmpty() && !graph.edgesOf(query).isEmpty()) {
 			final F M = graph.edgesOf(query).stream()
 					.map(edge -> {
 						final Integer s = graph.getEdgeSource(edge);


### PR DESCRIPTION
When using a disjoint graph (as an example, the result of a CutObserved preprocessing where one query node is isolated from the other)  as an input for a LoopyBeliefPropagation, an exception is raised. The issue is generated from an empty list of incoming edfges cause by the disjoint graph.

This change fix this issue by checking if we have any incoming edges for a query node.